### PR TITLE
This minor change fixes a redirecting link to a blog post about the project.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -69,7 +69,7 @@ div.form-container div.controlset label { width: 100px;}
 
 	<h2>Really Simple Color Picker (jQuery)</h2>
 
-	<p>More information about this can be found in <a href="http://www.laktek.com/2008/10/27/really-simple-color-picker-in-jquery/" title="Really Simple Color Picker in jQuery">this blog article</a>.</p>
+	<p>More information about this can be found in <a href="http://laktek.com/2008/10/27/really-simple-color-picker-in-jquery/" title="Really Simple Color Picker in jQuery">this blog article</a>.</p>
 	<div class="form-container">
 	<form action="#" method="post">
 		<fieldset>


### PR DESCRIPTION
The "www" in the link to the blog post for more information about the color picker forces the page to redirect to the laktek.com homepage. By removing the "www", it hits the correct post.
