### PR TITLE
Fix crash when setting input.type= in oldIE

### DIFF
--- a/jquery.colorPicker.js
+++ b/jquery.colorPicker.js
@@ -146,7 +146,11 @@
 
             // Hide the original input.
             if (element[0].tagName.toLowerCase() === 'input') {
-                element.each(function () { this.type = 'hidden' });
+                try {
+                    element.attr('type', 'hidden')
+                } catch(err) { // oldIE doesn't allow changing of input.type
+                    element.css('visibility', 'hidden').css('position', 'absolute')
+                }
             } else {
                 element.hide();
             }


### PR DESCRIPTION
Old versions of IE don't allow you to set `.type =` on an `input` element. You can't do it by other means (jQuery's `attr()`, or js `setAttribute()`) either.

So thee input is now hidden via css (`visilibility: hidden; position: absolute;`) in cases where it can't have its type changed. I didn't use `display:none;` as this would prevent the input value from being posted.
