### PR TITLE
HexField should be set whenever the input val changes

### DIFF
--- a/jquery.colorPicker.js
+++ b/jquery.colorPicker.js
@@ -137,9 +137,9 @@
             element.after(newControl);
 
             element.bind("change", function () {
-                element.next(".colorPicker-picker").css(
-                    "background-color", $.fn.colorPicker.toHex($(this).val())
-                );
+                var hexColor = $.fn.colorPicker.toHex($(this).val());
+                element.next(".colorPicker-picker").css("background-color", hexColor);
+                newHexField.val(hexColor);
             });
 
             element.val(defaultColor);


### PR DESCRIPTION
On your [demo page](http://laktek.github.io/really-simple-color-picker/demo.html):
Click the "Set Color 1 to #FFF", then click the color picker and hover over a swatch. It will revert back to the hex color instead of staying #FFF.  This fixes that.
