### PR TITLE
removed overwritten val()

### DIFF
--- a/js/jquery.colorPicker.js
+++ b/js/jquery.colorPicker.js
@@ -305,11 +305,7 @@
                 },
                 mouseout : function (ev) {
                     $(this).css("border-color", "#000");
-
-                    paletteInput.val(selectorOwner.css("background-color"));
-
                     paletteInput.val(lastColor);
-
                     $.fn.colorPicker.previewColor(lastColor);
                 }
             });


### PR DESCRIPTION
Hi!

The original code has this snippet:

paletteInput.val(selectorOwner.css("background-color"));
paletteInput.val(lastColor);

The second line will always override the first one, I guess, so I think it can be removed.