### PR TITLE
on keyup update the field value (helps copy/paste...)

### DIFF
--- a/js/jquery.colorPicker.js
+++ b/js/jquery.colorPicker.js
@@ -98,7 +98,11 @@
 
             newHexField.bind("keyup", function (event) {
               var hexColor = $.fn.colorPicker.toHex($(event.target).val());
-              $.fn.colorPicker.previewColor(hexColor ? hexColor : element.val());
+              if(hexColor){
+                $.fn.colorPicker.previewColor(hexColor);
+                selectorOwner.prev("input").val(hexColor).change();
+                newHexField.val(hexColor);
+              }
             });
 
             $('<div class="colorPicker_hexWrap" />').append(newHexLabel).appendTo(newPalette);


### PR DESCRIPTION
On each key up, set the new value is correct.
Allows:
- copy/paste save value
- enter a value without the need to press 'enter'
- fix https://github.com/laktek/really-simple-color-picker/issues/24
